### PR TITLE
[FIX] .env を正しく設定できなかった問題を修正

### DIFF
--- a/dist/lamp.js
+++ b/dist/lamp.js
@@ -7,18 +7,19 @@ var path = require("path");
 var color = require("cli-color");
 var yargs = require("yargs");
 var libs = require("./libs");
-require('dotenv').config();
 console.log();
 var argv = yargs
     .help(false)
     .option('mode', {
     describe: '実行モードを指定',
     alias: 'm',
-    default: 'default'
+    default: ''
 })
     .argv;
 if ('mode' in argv && argv.mode.length)
     process.env.LAMPMAN_MODE = argv.mode;
+if (!process.env.LAMPMAN_MODE)
+    process.env.LAMPMAN_MODE = 'default';
 var lampman = {
     mode: process.env.LAMPMAN_MODE
 };

--- a/src/lamp.ts
+++ b/src/lamp.ts
@@ -8,9 +8,7 @@ import fs    = require('fs')
 import path  = require('path')
 import color = require('cli-color')
 import yargs = require('yargs')
-import child  = require('child_process')
 import libs  = require('./libs')
-require('dotenv').config()
 
 // 1行改行
 console.log()
@@ -22,11 +20,12 @@ let argv = yargs
         {
             describe: '実行モードを指定',
             alias: 'm',
-            default: 'default'
+            default: ''
         }
     )
     .argv
 if('mode' in argv && argv.mode.length) process.env.LAMPMAN_MODE = argv.mode
+if(!process.env.LAMPMAN_MODE) process.env.LAMPMAN_MODE = 'default'
 
 // Lampmanオブジェクト用意
 let lampman: any = {


### PR DESCRIPTION
yargsのmode引数のデフォ値を設定していたために、`default` が勝手に入ってきたのが原因。
修正しました。
close #3 